### PR TITLE
Switch to using ActiveSupport::Concern

### DIFF
--- a/lib/socialization/follow_store.rb
+++ b/lib/socialization/follow_store.rb
@@ -1,14 +1,14 @@
 module Socialization
   module FollowStore
-    def self.included(base)
-      base.class_eval do
-        belongs_to :follower,   :polymorphic => true
-        belongs_to :followable, :polymorphic => true
+    extend ActiveSupport::Concern
 
-        validates_uniqueness_of :followable_type, :scope => [:followable_id, :follower_type, :follower_id], :message => 'You cannot follow the same thing twice.'
+    included do
+      belongs_to :follower,   :polymorphic => true
+      belongs_to :followable, :polymorphic => true
 
-        def self.human_attribute_name(*args); ''; end
-      end
+      validates_uniqueness_of :followable_type, :scope => [:followable_id, :follower_type, :follower_id], :message => 'You cannot follow the same thing twice.'
+
+      def self.human_attribute_name(*args); ''; end
     end
   end
 end

--- a/lib/socialization/followable.rb
+++ b/lib/socialization/followable.rb
@@ -8,23 +8,23 @@ end
 
 module Socialization
   module Followable
-    def self.included(base)
-      base.class_eval do
-        # A following is the Follow record of the follower following self.
-        has_many :followings, :as => :followable, :dependent => :destroy, :class_name => 'Follow'
+    extend ActiveSupport::Concern
 
-        def is_followable?
-          true
-        end
+    included do
+      # A following is the Follow record of the follower following self.
+      has_many :followings, :as => :followable, :dependent => :destroy, :class_name => 'Follow'
 
-        def followed_by?(follower)
-          raise ArgumentError, "#{follower} is not a follower!" unless follower.is_follower?
-          !self.followings.where(:follower_type => follower.class.to_s, :follower_id => follower.id).empty?
-        end
+      def is_followable?
+        true
+      end
 
-        def followers
-          self.followings.map { |f| f.follower }
-        end
+      def followed_by?(follower)
+        raise ArgumentError, "#{follower} is not a follower!" unless follower.is_follower?
+        !self.followings.where(:follower_type => follower.class.to_s, :follower_id => follower.id).empty?
+      end
+
+      def followers
+        self.followings.map { |f| f.follower }
       end
     end
   end

--- a/lib/socialization/follower.rb
+++ b/lib/socialization/follower.rb
@@ -8,36 +8,36 @@ end
 
 module Socialization
   module Follower
-    def self.included(base)
-      base.class_eval do
-        # A follow is the Follow record of self following a followable record.
-        has_many :follows, :as => :follower, :dependent => :destroy, :class_name => 'Follow'
+    extend ActiveSupport::Concern
 
-        def is_follower?
-          true
-        end
+    included do
+      # A follow is the Follow record of self following a followable record.
+      has_many :follows, :as => :follower, :dependent => :destroy, :class_name => 'Follow'
 
-        def follow!(followable)
-          raise ArgumentError, "#{followable} is not followable!" unless followable.is_followable?
-          raise ArgumentError, "#{self} cannot follow itself!" unless self != followable
-          Follow.create!({ :follower => self, :followable => followable }, :without_protection => true)
-        end
-
-        def unfollow!(followable)
-          ff = followable.followings.where(:follower_type => self.class.to_s, :follower_id => self.id)
-          unless ff.empty?
-            ff.each { |f| f.destroy }
-          else
-            raise ActiveRecord::RecordNotFound
-          end
-        end
-
-        def follows?(followable)
-          raise ArgumentError, "#{followable} is not followable!" unless followable.is_followable?
-          !self.follows.where(:followable_type => followable.class.to_s, :followable_id => followable.id).empty?
-        end
-
+      def is_follower?
+        true
       end
+
+      def follow!(followable)
+        raise ArgumentError, "#{followable} is not followable!" unless followable.is_followable?
+        raise ArgumentError, "#{self} cannot follow itself!" unless self != followable
+        Follow.create!({ :follower => self, :followable => followable }, :without_protection => true)
+      end
+
+      def unfollow!(followable)
+        ff = followable.followings.where(:follower_type => self.class.to_s, :follower_id => self.id)
+        unless ff.empty?
+          ff.each { |f| f.destroy }
+        else
+          raise ActiveRecord::RecordNotFound
+        end
+      end
+
+      def follows?(followable)
+        raise ArgumentError, "#{followable} is not followable!" unless followable.is_followable?
+        !self.follows.where(:followable_type => followable.class.to_s, :followable_id => followable.id).empty?
+      end
+
     end
   end
 end

--- a/lib/socialization/hello.rb
+++ b/lib/socialization/hello.rb
@@ -1,12 +1,12 @@
+require 'active_support/concern'
+
 %w{followable follower follow_store likeable liker like_store}.each do |f|
   require "#{File.dirname(__FILE__)}/#{f}"
 end
 
 module Socialization
   module Hello
-    def self.included(klass)
-      klass.send(:extend, ClassMethods)
-    end
+    extend ActiveSupport::Concern
 
     module ClassMethods
       def acts_as_follower(opts = nil)

--- a/lib/socialization/like_store.rb
+++ b/lib/socialization/like_store.rb
@@ -1,14 +1,14 @@
 module Socialization
   module LikeStore
-    def self.included(base)
-      base.class_eval do
-        belongs_to :liker,    :polymorphic => true
-        belongs_to :likeable, :polymorphic => true
+    extend ActiveSupport::Concern
 
-        validates_uniqueness_of :likeable_type, :scope => [:likeable_id, :liker_type, :liker_id], :message => 'You cannot like the same thing twice.'
+    included do
+      belongs_to :liker,    :polymorphic => true
+      belongs_to :likeable, :polymorphic => true
 
-        def self.human_attribute_name(*args); ''; end
-      end
+      validates_uniqueness_of :likeable_type, :scope => [:likeable_id, :liker_type, :liker_id], :message => 'You cannot like the same thing twice.'
+
+      def self.human_attribute_name(*args); ''; end
     end
   end
 end

--- a/lib/socialization/likeable.rb
+++ b/lib/socialization/likeable.rb
@@ -8,23 +8,23 @@ end
 
 module Socialization
   module Likeable
-    def self.included(base)
-      base.class_eval do
-        # A liking is the Like record of the liker liking self.
-        has_many :likings, :as => :likeable, :dependent => :destroy, :class_name => 'Like'
+    extend ActiveSupport::Concern
 
-        def is_likeable?
-          true
-        end
+    included do
+      # A liking is the Like record of the liker liking self.
+      has_many :likings, :as => :likeable, :dependent => :destroy, :class_name => 'Like'
 
-        def liked_by?(liker)
-          raise ArgumentError, "#{liker} is not a liker!" unless liker.is_liker?
-          !self.likings.where(:liker_type => liker.class.to_s, :liker_id => liker.id).empty?
-        end
+      def is_likeable?
+        true
+      end
 
-        def likers
-          self.likings.map { |l| l.liker }
-        end
+      def liked_by?(liker)
+        raise ArgumentError, "#{liker} is not a liker!" unless liker.is_liker?
+        !self.likings.where(:liker_type => liker.class.to_s, :liker_id => liker.id).empty?
+      end
+
+      def likers
+        self.likings.map { |l| l.liker }
       end
     end
   end

--- a/lib/socialization/liker.rb
+++ b/lib/socialization/liker.rb
@@ -8,40 +8,40 @@ end
 
 module Socialization
   module Liker
-    def self.included(base)
-      base.class_eval do
-        # A like is the Like record of self liking a likeable record.
-        has_many :likes, :as => :liker, :dependent => :destroy, :class_name => 'Like'
+    extend ActiveSupport::Concern
 
-        def is_liker?
-          true
-        end
+    included do
+      # A like is the Like record of self liking a likeable record.
+      has_many :likes, :as => :liker, :dependent => :destroy, :class_name => 'Like'
 
-        def like!(likeable)
-          ensure_likeable!(likeable)
-          raise ArgumentError, "#{self} cannot like itself!" unless self != likeable
-          Like.create!({ :liker => self, :likeable => likeable }, :without_protection => true)
-        end
-
-        def unlike!(likeable)
-          ll = likeable.likings.where(:liker_type => self.class.to_s, :liker_id => self.id)
-          unless ll.empty?
-            ll.each { |l| l.destroy }
-          else
-            raise ActiveRecord::RecordNotFound
-          end
-        end
-
-        def likes?(likeable)
-          ensure_likeable!(likeable)
-          !self.likes.where(:likeable_type => likeable.class.to_s, :likeable_id => likeable.id).empty?
-        end
-
-        private
-          def ensure_likeable!(likeable)
-            raise ArgumentError, "#{likeable} is not likeable!" unless likeable.is_likeable?
-          end
+      def is_liker?
+        true
       end
+
+      def like!(likeable)
+        ensure_likeable!(likeable)
+        raise ArgumentError, "#{self} cannot like itself!" unless self != likeable
+        Like.create!({ :liker => self, :likeable => likeable }, :without_protection => true)
+      end
+
+      def unlike!(likeable)
+        ll = likeable.likings.where(:liker_type => self.class.to_s, :liker_id => self.id)
+        unless ll.empty?
+          ll.each { |l| l.destroy }
+        else
+          raise ActiveRecord::RecordNotFound
+        end
+      end
+
+      def likes?(likeable)
+        ensure_likeable!(likeable)
+        !self.likes.where(:likeable_type => likeable.class.to_s, :likeable_id => likeable.id).empty?
+      end
+
+      private
+        def ensure_likeable!(likeable)
+          raise ArgumentError, "#{likeable} is not likeable!" unless likeable.is_likeable?
+        end
     end
   end
 end


### PR DESCRIPTION
I changed the self.included(base) things to ActiveSupport::Concern.
This I think is now how module inclusion should work.

Less code, handles module dependencies, intent is clearer.
http://api.rubyonrails.org/classes/ActiveSupport/Concern.html

I hope you like it! All the tests still pass.
