### PR TITLE
add shortcut methods

### DIFF
--- a/lib/socialization/followable.rb
+++ b/lib/socialization/followable.rb
@@ -39,6 +39,25 @@ module Socialization
               where("follows.followable_type = '#{self.class.to_s}'").
               where("follows.followable_id   =  #{self.id}")
       end
+
+      # Add a shortcut for the +followers+ method combined with the name of the class.
+      # This allows you to ask for <tt>user_followers</tt> instead of <tt>followers(User)</tt>.
+      def method_missing(method, *arguments, &block)
+        if method.to_s =~ /(.*)_followers$/
+          followers($1)
+        else
+          super
+        end
+      end
+
+      # Assert that this class responds to the dynamic followers-method.
+      def respond_to?(method)
+        if method.to_s =~ /(.*)_followers$/
+          true
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/lib/socialization/follower.rb
+++ b/lib/socialization/follower.rb
@@ -79,6 +79,25 @@ module Socialization
               where("follows.follower_id   =  #{self.id}")
 
       end
+
+      # Add a shortcut method for the +followees+ method combined with the name of the class.
+      # This allows you to ask for <tt>user_followees</tt> instead of <tt>followees(User)</tt>.
+      def method_missing(method, *arguments, &block)
+        if method.to_s =~ /(.*)_followees$/
+          followees($1)
+        else
+          super
+        end
+      end
+
+      # Assert that this class responds to the dynamic followees-method.
+      def respond_to?(method)
+        if method.to_s =~ /(.*)_followees$/
+          true
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/lib/socialization/likeable.rb
+++ b/lib/socialization/likeable.rb
@@ -39,6 +39,25 @@ module Socialization
               where("likes.likeable_type = '#{self.class.to_s}'").
               where("likes.likeable_id   =  #{self.id}")
       end
+
+      # Add a shortcut for the +likers+ method combined with the name of the class.
+      # This allows you to ask for <tt>user_likers</tt> instead of <tt>likers(User)</tt>.
+      def method_missing(method, *arguments, &block)
+        if method.to_s =~ /(.*)_likers$/
+          likers($1)
+        else
+          super
+        end
+      end
+
+      # Assert that this class responds to the dynamic likers-method.
+      def respond_to?(method)
+        if method.to_s =~ /(.*)_likers$/
+          true
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/lib/socialization/liker.rb
+++ b/lib/socialization/liker.rb
@@ -78,6 +78,25 @@ module Socialization
               where("likes.liker_id   =  #{self.id}")
       end
 
+      # Add a shortcut for the +likees+ method combined with the name of the class.
+      # This allows you to ask for <tt>user_likees</tt> instead of <tt>likees(User)</tt>.
+      def method_missing(method, *arguments, &block)
+        if method.to_s =~ /(.*)_likees$/
+          likees($1)
+        else
+          super
+        end
+      end
+
+       # Assert that this class responds to the dynamic likees-method.
+      def respond_to?(method)
+        if method.to_s =~ /(.*)_likees$/
+          true
+        else
+          super
+        end
+      end
+
       private
         def ensure_likeable!(likeable)
           raise ArgumentError, "#{likeable} is not likeable!" unless likeable.is_likeable?

--- a/lib/socialization/mentionable.rb
+++ b/lib/socialization/mentionable.rb
@@ -41,6 +41,24 @@ module Socialization
               where("mentions.mentionable_id   =  #{self.id}")
       end
 
+      # Add a shortcut for the +mentioners+ method combined with the name of the class.
+      # This allows you to ask for <tt>user_mentioners</tt> instead of <tt>mentioners(User)</tt>.
+      def method_missing(method, *arguments, &block)
+        if method.to_s =~ /(.*)_mentioners$/
+          mentioners($1)
+        else
+          super
+        end
+      end
+
+      # Assert that this class responds to the dynamic mentioners-method.
+      def respond_to?(method)
+        if method.to_s =~ /(.*)_mentioners$/
+          true
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/lib/socialization/mentioner.rb
+++ b/lib/socialization/mentioner.rb
@@ -77,6 +77,25 @@ module Socialization
               where("mentions.mentioner_id   =  #{self.id}")
       end
 
+      # Add a shortcut for the +mentionees+ method combined with the name of the class.
+      # This allows you to ask for <tt>user_mentionees</tt> instead of <tt>mentionees(User)</tt>.
+      def method_missing(method, *arguments, &block)
+        if method.to_s =~ /(.*)_mentionees$/
+          mentionees($1)
+        else
+          super
+        end
+      end
+
+      # Assert that this class responds to the dynamic mentionees-method.
+      def respond_to?(method)
+        if method.to_s =~ /(.*)_mentionees$/
+          true
+        else
+          super
+        end
+      end
+
       private
         def ensure_mentionable!(mentionable)
           raise ArgumentError, "#{mentionable} is not mentionable!" unless mentionable.is_mentionable?

--- a/test/follow_test.rb
+++ b/test/follow_test.rb
@@ -54,6 +54,13 @@ class FollowTest < Test::Unit::TestCase
       assert_equal @follower1.followees(ImAFollowable), @follower1.followees(:im_a_followables)
       assert_equal @follower1.followees(ImAFollowable), @follower1.followees("im_a_followable")
     end
+
+    should "expose a shortcut method for its followees" do
+      Follow.create :follower => @follower1, :followable => @followable1
+
+      assert @follower1.respond_to?(:im_a_followable_followees)
+      assert_equal @follower1.followees(ImAFollowable), @follower1.im_a_followable_followees
+    end
   end
 
   context "a Followable" do
@@ -78,6 +85,13 @@ class FollowTest < Test::Unit::TestCase
 
       assert_equal @followable1.followers(ImAFollower), @followable1.followers(:im_a_followers)
       assert_equal @followable1.followers(ImAFollower), @followable1.followers("im_a_follower")
+    end
+
+    should "expose a shortcut method for its followers" do
+      Follow.create :follower => @follower1, :followable => @followable1
+
+      assert @followable1.respond_to?(:im_a_follower_followers)
+      assert_equal @followable1.followers(ImAFollower), @followable1.im_a_follower_followers
     end
 
     should "expose followings" do

--- a/test/like_test.rb
+++ b/test/like_test.rb
@@ -46,13 +46,20 @@ class LikeTest < Test::Unit::TestCase
       assert_true  @liker1.likes?(@likeable1)
     end
 
-    should "expose a list of its likes" do
+    should "expose a list of its likees" do
       Like.create :liker => @liker1, :likeable => @likeable1
       assert @liker1.likees(ImALikeable).is_a?(ActiveRecord::Relation)
       assert_equal [@likeable1], @liker1.likees(ImALikeable).all
 
       assert_equal @liker1.likees(ImALikeable), @liker1.likees(:im_a_likeables)
       assert_equal @liker1.likees(ImALikeable), @liker1.likees("im_a_likeable")
+    end
+
+    should "expose a shortcut method for its likees" do
+      Like.create :liker => @liker1, :likeable => @likeable1
+
+      assert @liker1.respond_to?(:im_a_likeable_likees)
+      assert_equal @liker1.likees(ImALikeable), @liker1.im_a_likeable_likees
     end
   end
 
@@ -78,6 +85,13 @@ class LikeTest < Test::Unit::TestCase
 
       assert_equal @likeable1.likers(ImALiker), @likeable1.likers(:im_a_likers)
       assert_equal @likeable1.likers(ImALiker), @likeable1.likers("im_a_liker")
+    end
+
+    should "expose a shortcut method for its likers" do
+      Like.create :liker => @liker1, :likeable => @likeable1
+
+      assert @likeable1.respond_to?(:im_a_liker_likers)
+      assert_equal @likeable1.likers(ImALiker), @likeable1.im_a_liker_likers
     end
 
     should "expose likings" do

--- a/test/mention_test.rb
+++ b/test/mention_test.rb
@@ -58,6 +58,13 @@ class MentionTest < Test::Unit::TestCase
       assert_equal @mentioner1.mentionees(ImAMentionable), @mentioner1.mentionees(:im_a_mentionables)
       assert_equal @mentioner1.mentionees(ImAMentionable), @mentioner1.mentionees("im_a_mentionable")
     end
+
+    should "expose a shortcut method for its mentionees" do
+      Mention.create :mentioner => @mentioner1, :mentionable => @mentionable1
+
+      assert @mentioner1.respond_to?(:im_a_mentionable_mentionees)
+      assert_equal @mentioner1.mentionees(ImAMentionable), @mentioner1.im_a_mentionable_mentionees
+    end
   end
 
   context "a Mentionable" do
@@ -82,6 +89,13 @@ class MentionTest < Test::Unit::TestCase
 
       assert_equal @mentionable1.mentioners(ImAMentioner), @mentionable1.mentioners(:im_a_mentioners)
       assert_equal @mentionable1.mentioners(ImAMentioner), @mentionable1.mentioners("im_a_mentioner")
+    end
+
+    should "expose a shortcut method for its mentioners" do
+      Mention.create :mentioner => @mentioner1, :mentionable => @mentionable1
+
+      assert @mentionable1.respond_to?(:im_a_mentioner_mentioners)
+      assert_equal @mentionable1.mentioners(ImAMentioner), @mentionable1.im_a_mentioner_mentioners
     end
 
     should "expose mentionings" do


### PR DESCRIPTION
I was working on this branch since I like user_likers better than likers(User). Maybe it's personal taste. :smile:

All the test pass _except_ the one for the dynamic _mentionees method. It complains with an error I don't really understand. Maybe you do? Do you like this change or are you not interested? I'm cool either way :D
