### PR TITLE
Add to support AR counter cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ All followers
 
     celebrity.followers(User)
 
+Number of followers (Requires followers_count column in db)
+
+    def change
+      add_column :#{Table_name}, :followers_count, :integer, :default => 0
+    end
+
+    celebrity.followers_count
 
 ***
 
@@ -167,6 +174,14 @@ Find out if an objects likes
 All likers
 
     movie.likers(User)
+
+Number of likers (Requires likers_count column in db)
+
+    def change
+      add_column :#{Table_name}, :likers_count, :integer, :default => 0
+    end
+
+    movie.likers_count
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ What items are you following (given that an Item model is followed)?
 
     user.followees(Item)
 
+Number of followees (Requires followees_count column in db)
+
+    def change
+      add_column :#{Table_name}, :followees_count, :integer, :default => 0
+    end
+
+    user.followees_count
 
 ***
 
@@ -161,6 +168,14 @@ Toggle
 Likes?
 
     user.likes?(movie)
+
+Number of likees (Requires likees_count column in db)
+
+    def change
+      add_column :#{Table_name}, :likees_count, :integer, :default => 0
+    end
+
+    user.likees_count
 
 ***
 
@@ -210,6 +225,14 @@ All mentionees
 
     comment.mentionees(User)
 
+Number of mentionees (Requires mentionees column in db)
+
+    def change
+      add_column :#{Table_name}, : mentionees, :integer, :default => 0
+    end
+
+    user. mentionees_count
+
 ***
 
 
@@ -223,6 +246,13 @@ All mentioners
 
     user.mentioners(Comment)
 
+Number of mentioners (Requires mentioners_count column in db)
+
+    def change
+      add_column :#{Table_name}, :mentioners_count, :integer, :default => 0
+    end
+
+    movie.mentioners_count
 
 ***
 

--- a/lib/socialization/stores/active_record/follow.rb
+++ b/lib/socialization/stores/active_record/follow.rb
@@ -25,6 +25,7 @@ module Socialization
               follow.follower = follower
               follow.followable = followable
             end
+            followable.class.increment_counter(:followers_count, followable.id) if followable.respond_to?(:followers_count)
             call_after_create_hooks(follower, followable)
             true
           else
@@ -35,6 +36,7 @@ module Socialization
         def unfollow!(follower, followable)
           if follows?(follower, followable)
             follow_for(follower, followable).destroy_all
+            followable.class.decrement_counter(:followers_count, followable.id) if followable.respond_to?(:followers_count)
             call_after_destroy_hooks(follower, followable)
             true
           else

--- a/lib/socialization/stores/active_record/follow.rb
+++ b/lib/socialization/stores/active_record/follow.rb
@@ -25,7 +25,8 @@ module Socialization
               follow.follower = follower
               follow.followable = followable
             end
-            followable.class.increment_counter(:followers_count, followable.id) if followable.respond_to?(:followers_count)
+            update_counter(follower, followees_count: +1)
+            update_counter(followable, followers_count: +1)
             call_after_create_hooks(follower, followable)
             true
           else
@@ -36,7 +37,8 @@ module Socialization
         def unfollow!(follower, followable)
           if follows?(follower, followable)
             follow_for(follower, followable).destroy_all
-            followable.class.decrement_counter(:followers_count, followable.id) if followable.respond_to?(:followers_count)
+            update_counter(follower, followees_count: -1)
+            update_counter(followable, followers_count: -1)
             call_after_destroy_hooks(follower, followable)
             true
           else

--- a/lib/socialization/stores/active_record/like.rb
+++ b/lib/socialization/stores/active_record/like.rb
@@ -25,6 +25,7 @@ module Socialization
               like.liker = liker
               like.likeable = likeable
             end
+            likeable.class.increment_counter(:likers_count, likeable.id) if likeable.respond_to?(:likers_count)
             call_after_create_hooks(liker, likeable)
             true
           else
@@ -35,6 +36,7 @@ module Socialization
         def unlike!(liker, likeable)
           if likes?(liker, likeable)
             like_for(liker, likeable).destroy_all
+            likeable.class.decrement_counter(:likers_count, likeable.id) if likeable.respond_to?(:likers_count)
             call_after_destroy_hooks(liker, likeable)
             true
           else

--- a/lib/socialization/stores/active_record/like.rb
+++ b/lib/socialization/stores/active_record/like.rb
@@ -25,7 +25,8 @@ module Socialization
               like.liker = liker
               like.likeable = likeable
             end
-            likeable.class.increment_counter(:likers_count, likeable.id) if likeable.respond_to?(:likers_count)
+            update_counter(liker, likees_count: +1)
+            update_counter(likeable, likers_count: +1)
             call_after_create_hooks(liker, likeable)
             true
           else
@@ -36,7 +37,8 @@ module Socialization
         def unlike!(liker, likeable)
           if likes?(liker, likeable)
             like_for(liker, likeable).destroy_all
-            likeable.class.decrement_counter(:likers_count, likeable.id) if likeable.respond_to?(:likers_count)
+            update_counter(liker, likees_count: -1)
+            update_counter(likeable, likers_count: -1)
             call_after_destroy_hooks(liker, likeable)
             true
           else

--- a/lib/socialization/stores/active_record/mention.rb
+++ b/lib/socialization/stores/active_record/mention.rb
@@ -25,6 +25,8 @@ module Socialization
               mention.mentioner = mentioner
               mention.mentionable = mentionable
             end
+            update_counter(mentioner, mentionees_count: +1)
+            update_counter(mentionable, mentioners_count: +1)
             call_after_create_hooks(mentioner, mentionable)
             true
           else
@@ -35,6 +37,8 @@ module Socialization
         def unmention!(mentioner, mentionable)
           if mentions?(mentioner, mentionable)
             mention_for(mentioner, mentionable).destroy_all
+            update_counter(mentioner, mentionees_count: -1)
+            update_counter(mentionable, mentioners_count: -1)
             call_after_destroy_hooks(mentioner, mentionable)
             true
           else

--- a/lib/socialization/stores/active_record/mixins/base.rb
+++ b/lib/socialization/stores/active_record/mixins/base.rb
@@ -2,6 +2,10 @@ module Socialization
   module ActiveRecordStores
     module Mixins
       module Base
+        def update_counter(model, counter)
+          column_name, _ = counter.first
+          model.class.update_counters model.id, counter if model.respond_to?(column_name)
+        end
       end
     end
   end

--- a/test/stores/active_record/follow_store_test.rb
+++ b/test/stores/active_record/follow_store_test.rb
@@ -24,6 +24,16 @@ class ActiveRecordFollowStoreTest < Test::Unit::TestCase
         assert_match_followable @klass.last, @followable
       end
 
+      should "increase counter cache if column exists" do
+        assert_nothing_raised do
+          @klass.follow!(@follower, @followable)
+        end
+
+        followable_with_counter_cache = ImAFollowableWithCounterCache.create
+        @klass.follow!(@follower, followable_with_counter_cache)
+        assert_equal 1, followable_with_counter_cache.reload.followers_count
+      end
+
       should "touch follower when instructed" do
         @klass.touch :follower
         @follower.expects(:touch).once

--- a/test/stores/active_record/follow_store_test.rb
+++ b/test/stores/active_record/follow_store_test.rb
@@ -24,14 +24,12 @@ class ActiveRecordFollowStoreTest < Test::Unit::TestCase
         assert_match_followable @klass.last, @followable
       end
 
-      should "increase counter cache if column exists" do
-        assert_nothing_raised do
-          @klass.follow!(@follower, @followable)
-        end
-
-        followable_with_counter_cache = ImAFollowableWithCounterCache.create
-        @klass.follow!(@follower, followable_with_counter_cache)
-        assert_equal 1, followable_with_counter_cache.reload.followers_count
+      should "increment counter caches" do
+        follower   = ImAFollowerWithCounterCache.create
+        followable = ImAFollowableWithCounterCache.create
+        @klass.follow!(follower, followable)
+        assert_equal 1, follower.reload.followees_count
+        assert_equal 1, followable.reload.followers_count
       end
 
       should "touch follower when instructed" do
@@ -65,6 +63,17 @@ class ActiveRecordFollowStoreTest < Test::Unit::TestCase
         @klass.after_follow :after_unfollow
         @klass.expects(:after_unfollow).once
         @klass.follow!(@follower, @followable)
+      end
+    end
+
+    context "#unfollow!" do
+      should "decrement counter caches" do
+        follower   = ImAFollowerWithCounterCache.create
+        followable = ImAFollowableWithCounterCache.create
+        @klass.follow!(follower, followable)
+        @klass.unfollow!(follower, followable)
+        assert_equal 0, follower.reload.followees_count
+        assert_equal 0, followable.reload.followers_count
       end
     end
 

--- a/test/stores/active_record/like_store_test.rb
+++ b/test/stores/active_record/like_store_test.rb
@@ -24,6 +24,16 @@ class ActiveRecordLikeStoreTest < Test::Unit::TestCase
         assert_match_likeable @klass.last, @likeable
       end
 
+      should "increase counter cache if column exists" do
+        assert_nothing_raised do
+          @klass.like!(@liker, @likeable)
+        end
+
+        likeable_with_counter_cache = ImALikeableWithCounterCache.create
+        @klass.like!(@liker, likeable_with_counter_cache)
+        assert_equal 1, likeable_with_counter_cache.reload.likers_count
+      end
+
       should "touch liker when instructed" do
         @klass.touch :liker
         @liker.expects(:touch).once

--- a/test/stores/active_record/like_store_test.rb
+++ b/test/stores/active_record/like_store_test.rb
@@ -24,14 +24,12 @@ class ActiveRecordLikeStoreTest < Test::Unit::TestCase
         assert_match_likeable @klass.last, @likeable
       end
 
-      should "increase counter cache if column exists" do
-        assert_nothing_raised do
-          @klass.like!(@liker, @likeable)
-        end
-
-        likeable_with_counter_cache = ImALikeableWithCounterCache.create
-        @klass.like!(@liker, likeable_with_counter_cache)
-        assert_equal 1, likeable_with_counter_cache.reload.likers_count
+      should "increment counter caches" do
+        liker    = ImALikerWithCounterCache.create
+        likeable = ImALikeableWithCounterCache.create
+        @klass.like!(liker, likeable)
+        assert_equal 1, liker.reload.likees_count
+        assert_equal 1, likeable.reload.likers_count
       end
 
       should "touch liker when instructed" do
@@ -65,6 +63,17 @@ class ActiveRecordLikeStoreTest < Test::Unit::TestCase
         @klass.after_like :after_unlike
         @klass.expects(:after_unlike).once
         @klass.like!(@liker, @likeable)
+      end
+    end
+
+    context "#unlike!" do
+      should "decrement counter caches" do
+        liker    = ImALikerWithCounterCache.create
+        likeable = ImALikeableWithCounterCache.create
+        @klass.like!(liker, likeable)
+        @klass.unlike!(liker, likeable)
+        assert_equal 0, liker.reload.likees_count
+        assert_equal 0, likeable.reload.likers_count
       end
     end
 

--- a/test/stores/active_record/mention_store_test.rb
+++ b/test/stores/active_record/mention_store_test.rb
@@ -24,6 +24,14 @@ class ActiveRecordMentionStoreTest < Test::Unit::TestCase
         assert_match_mentionable @klass.last, @mentionable
       end
 
+      should "increment counter caches" do
+        mentioner   = ImAMentionerWithCounterCache.create
+        mentionable = ImAMentionableWithCounterCache.create
+        @klass.mention!(mentioner, mentionable)
+        assert_equal 1, mentioner.reload.mentionees_count
+        assert_equal 1, mentionable.reload.mentioners_count
+      end
+
       should "touch mentioner when instructed" do
         @klass.touch :mentioner
         @mentioner.expects(:touch).once
@@ -57,6 +65,18 @@ class ActiveRecordMentionStoreTest < Test::Unit::TestCase
         @klass.mention!(@mentioner, @mentionable)
       end
     end
+
+    context "#unmention!" do
+      should "decrement counter caches" do
+        mentioner   = ImAMentionerWithCounterCache.create
+        mentionable = ImAMentionableWithCounterCache.create
+        @klass.mention!(mentioner, mentionable)
+        @klass.unmention!(mentioner, mentionable)
+        assert_equal 0, mentioner.reload.mentionees_count
+        assert_equal 0, mentionable.reload.mentioners_count
+      end
+    end
+
 
     context "#mentions?" do
       should "return true when mention exists" do

--- a/test/stores/active_record/mixins/base_test.rb
+++ b/test/stores/active_record/mixins/base_test.rb
@@ -1,0 +1,28 @@
+require File.expand_path(File.dirname(__FILE__))+'/../../../test_helper'
+
+class ActiveRecordBaseStoreTest < Test::Unit::TestCase
+  context ".update_counter" do
+    should "increment counter cache if column exists" do
+      followable = ImAFollowableWithCounterCache.create
+
+      update_counter(followable, followers_count: +1)
+
+      assert_equal 1, followable.reload.followers_count
+    end
+
+    should "not raise any errors if column doesn't exist" do
+      followable = ImAFollowable.create
+
+      assert_nothing_raised do
+        update_counter(followable, followers_count: +1)
+      end
+    end
+  end
+
+  def update_counter(model, counter)
+    klass = Object.new
+    klass.extend(Socialization::ActiveRecordStores::Mixins::Base)
+    klass.update_counter(model, counter)
+  end
+end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -143,11 +143,21 @@ ActiveRecord::Schema.define(:version => 0) do
     t.timestamps
   end
 
+  create_table :im_a_followable_with_counter_caches do |t|
+    t.integer :followers_count, default: 0
+    t.timestamps
+  end
+
   create_table :im_a_likers do |t|
     t.timestamps
   end
 
   create_table :im_a_likeables do |t|
+    t.timestamps
+  end
+
+  create_table :im_a_likeable_with_counter_caches do |t|
+    t.integer :likers_count, default: 0
     t.timestamps
   end
 
@@ -206,6 +216,9 @@ class ImAFollowerChild < ImAFollower; end
 class ImAFollowable < ActiveRecord::Base
   acts_as_followable
 end
+class ImAFollowableWithCounterCache < ActiveRecord::Base
+  acts_as_followable
+end
 class ImAFollowableChild < ImAFollowable; end
 
 class ImALiker < ActiveRecord::Base
@@ -214,6 +227,9 @@ end
 class ImALikerChild < ImALiker; end
 
 class ImALikeable < ActiveRecord::Base
+  acts_as_likeable
+end
+class ImALikeableWithCounterCache < ActiveRecord::Base
   acts_as_likeable
 end
 class ImALikeableChild < ImALikeable; end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,13 +8,16 @@ require 'logger'
 require 'mock_redis' if $MOCK_REDIS
 require 'redis' unless $MOCK_REDIS
 require 'mocha' # mocha always needs to be loaded last! http://stackoverflow.com/questions/3118866/mocha-mock-carries-to-another-test/4375296#4375296
-# require 'pry'
 
 $:.push File.expand_path("../lib", __FILE__)
 require "socialization"
 
 silence_warnings do
   Redis = MockRedis if $MOCK_REDIS # Magic!
+end
+
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.irregular 'cache', 'caches'
 end
 
 module Test::Unit::Assertions
@@ -139,6 +142,11 @@ ActiveRecord::Schema.define(:version => 0) do
     t.timestamps
   end
 
+  create_table :im_a_follower_with_counter_caches do |t|
+    t.integer :followees_count, default: 0
+    t.timestamps
+  end
+
   create_table :im_a_followables do |t|
     t.timestamps
   end
@@ -149,6 +157,11 @@ ActiveRecord::Schema.define(:version => 0) do
   end
 
   create_table :im_a_likers do |t|
+    t.timestamps
+  end
+
+  create_table :im_a_liker_with_counter_caches do |t|
+    t.integer :likees_count, default: 0
     t.timestamps
   end
 
@@ -165,7 +178,17 @@ ActiveRecord::Schema.define(:version => 0) do
     t.timestamps
   end
 
+  create_table :im_a_mentioner_with_counter_caches do |t|
+    t.integer :mentionees_count, default: 0
+    t.timestamps
+  end
+
   create_table :im_a_mentionables do |t|
+    t.timestamps
+  end
+
+  create_table :im_a_mentionable_with_counter_caches do |t|
+    t.integer :mentioners_count, default: 0
     t.timestamps
   end
 
@@ -211,6 +234,9 @@ end
 class ImAFollower < ActiveRecord::Base
   acts_as_follower
 end
+class ImAFollowerWithCounterCache < ActiveRecord::Base
+  acts_as_follower
+end
 class ImAFollowerChild < ImAFollower; end
 
 class ImAFollowable < ActiveRecord::Base
@@ -222,6 +248,9 @@ end
 class ImAFollowableChild < ImAFollowable; end
 
 class ImALiker < ActiveRecord::Base
+  acts_as_liker
+end
+class ImALikerWithCounterCache < ActiveRecord::Base
   acts_as_liker
 end
 class ImALikerChild < ImALiker; end
@@ -237,9 +266,15 @@ class ImALikeableChild < ImALikeable; end
 class ImAMentioner < ActiveRecord::Base
   acts_as_mentioner
 end
+class ImAMentionerWithCounterCache < ActiveRecord::Base
+  acts_as_mentioner
+end
 class ImAMentionerChild < ImAMentioner; end
 
 class ImAMentionable < ActiveRecord::Base
+  acts_as_mentionable
+end
+class ImAMentionableWithCounterCache < ActiveRecord::Base
   acts_as_mentionable
 end
 class ImAMentionableChild < ImAMentionable; end


### PR DESCRIPTION
* Add to support `followers_count` counter cache on followable after `follower!` and `unfollow!`.
* Add to support `likers_count` counter cache on followable after `like!` and `unlike!`.

For me, I don't think it doesn't make sense much to add support on mentionable. Open for any feedbacks.

Thank @jdewzy for his initially pull request: #22

#19 