### PR TITLE
added compatibility with models with module/namespace

### DIFF
--- a/lib/socialization/stores/active_record/follow.rb
+++ b/lib/socialization/stores/active_record/follow.rb
@@ -9,12 +9,12 @@ module Socialization
       belongs_to :followable, :polymorphic => true
 
       scope :followed_by, lambda { |follower| where(
-        :follower_type   => follower.class.table_name.classify,
+        :follower_type   => follower.class.name.classify,
         :follower_id     => follower.id)
       }
 
       scope :following,   lambda { |followable| where(
-        :followable_type => followable.class.table_name.classify,
+        :followable_type => followable.class.name.classify,
         :followable_id   => followable.id)
       }
 
@@ -50,7 +50,7 @@ module Socialization
         def followers_relation(followable, klass, opts = {})
           rel = klass.where(:id =>
             self.select(:follower_id).
-              where(:follower_type => klass.table_name.classify).
+              where(:follower_type => klass.name.classify).
               where(:followable_type => followable.class.to_s).
               where(:followable_id => followable.id)
           )
@@ -76,7 +76,7 @@ module Socialization
         def followables_relation(follower, klass, opts = {})
           rel = klass.where(:id =>
             self.select(:followable_id).
-              where(:followable_type => klass.table_name.classify).
+              where(:followable_type => klass.name.classify).
               where(:follower_type => follower.class.to_s).
               where(:follower_id => follower.id)
           )

--- a/lib/socialization/stores/active_record/like.rb
+++ b/lib/socialization/stores/active_record/like.rb
@@ -9,12 +9,12 @@ module Socialization
       belongs_to :likeable, :polymorphic => true
 
       scope :liked_by, lambda { |liker| where(
-        :liker_type    => liker.class.table_name.classify,
+        :liker_type    => liker.class.name.classify,
         :liker_id      => liker.id)
       }
 
       scope :liking,   lambda { |likeable| where(
-        :likeable_type => likeable.class.table_name.classify,
+        :likeable_type => likeable.class.name.classify,
         :likeable_id   => likeable.id)
       }
 
@@ -50,7 +50,7 @@ module Socialization
         def likers_relation(likeable, klass, opts = {})
           rel = klass.where(:id =>
             self.select(:liker_id).
-              where(:liker_type => klass.table_name.classify).
+              where(:liker_type => klass.name.classify).
               where(:likeable_type => likeable.class.to_s).
               where(:likeable_id => likeable.id)
           )
@@ -76,7 +76,7 @@ module Socialization
         def likeables_relation(liker, klass, opts = {})
           rel = klass.where(:id =>
             self.select(:likeable_id).
-              where(:likeable_type => klass.table_name.classify).
+              where(:likeable_type => klass.name.classify).
               where(:liker_type => liker.class.to_s).
               where(:liker_id => liker.id)
           )

--- a/lib/socialization/stores/active_record/mention.rb
+++ b/lib/socialization/stores/active_record/mention.rb
@@ -9,12 +9,12 @@ module Socialization
       belongs_to :mentionable, :polymorphic => true
 
       scope :mentioned_by, lambda { |mentioner| where(
-        :mentioner_type   => mentioner.class.table_name.classify,
+        :mentioner_type   => mentioner.class.name.classify,
         :mentioner_id     => mentioner.id)
       }
 
       scope :mentioning,   lambda { |mentionable| where(
-        :mentionable_type => mentionable.class.table_name.classify,
+        :mentionable_type => mentionable.class.name.classify,
         :mentionable_id   => mentionable.id)
       }
 
@@ -50,7 +50,7 @@ module Socialization
         def mentioners_relation(mentionable, klass, opts = {})
           rel = klass.where(:id =>
             self.select(:mentioner_id).
-              where(:mentioner_type => klass.table_name.classify).
+              where(:mentioner_type => klass.name.classify).
               where(:mentionable_type => mentionable.class.to_s).
               where(:mentionable_id => mentionable.id)
           )
@@ -76,7 +76,7 @@ module Socialization
         def mentionables_relation(mentioner, klass, opts = {})
           rel = klass.where(:id =>
             self.select(:mentionable_id).
-              where(:mentionable_type => klass.table_name.classify).
+              where(:mentionable_type => klass.name.classify).
               where(:mentioner_type => mentioner.class.to_s).
               where(:mentioner_id => mentioner.id)
           )


### PR DESCRIPTION
follower.class.table_name.classify not work with models that have namespace, the method generates an incorrect value.

e.g.: Vehicle::Car will return VehicleCar instead Vehicle::Car causing error in the scopes