### PR TITLE
changed :id to klass.primary_key

### DIFF
--- a/lib/socialization/stores/active_record/follow.rb
+++ b/lib/socialization/stores/active_record/follow.rb
@@ -48,7 +48,7 @@ module Socialization
 
         # Returns an ActiveRecord::Relation of all the followers of a certain type that are following followable
         def followers_relation(followable, klass, opts = {})
-          rel = klass.where(:id =>
+          rel = klass.where(klass.primary_key =>
             self.select(:follower_id).
               where(:follower_type => klass.table_name.classify).
               where(:followable_type => followable.class.to_s).
@@ -74,7 +74,7 @@ module Socialization
 
         # Returns an ActiveRecord::Relation of all the followables of a certain type that are followed by follower
         def followables_relation(follower, klass, opts = {})
-          rel = klass.where(:id =>
+          rel = klass.where(klass.primary_key =>
             self.select(:followable_id).
               where(:followable_type => klass.table_name.classify).
               where(:follower_type => follower.class.to_s).

--- a/lib/socialization/stores/active_record/like.rb
+++ b/lib/socialization/stores/active_record/like.rb
@@ -48,7 +48,7 @@ module Socialization
 
         # Returns an ActiveRecord::Relation of all the likers of a certain type that are liking  likeable
         def likers_relation(likeable, klass, opts = {})
-          rel = klass.where(:id =>
+          rel = klass.where(klass.primary_key =>
             self.select(:liker_id).
               where(:liker_type => klass.table_name.classify).
               where(:likeable_type => likeable.class.to_s).
@@ -74,7 +74,7 @@ module Socialization
 
         # Returns an ActiveRecord::Relation of all the likeables of a certain type that are liked by liker
         def likeables_relation(liker, klass, opts = {})
-          rel = klass.where(:id =>
+          rel = klass.where(klass.primary_key =>
             self.select(:likeable_id).
               where(:likeable_type => klass.table_name.classify).
               where(:liker_type => liker.class.to_s).

--- a/lib/socialization/stores/active_record/mention.rb
+++ b/lib/socialization/stores/active_record/mention.rb
@@ -48,7 +48,7 @@ module Socialization
 
         # Returns an ActiveRecord::Relation of all the mentioners of a certain type that are mentioning mentionable
         def mentioners_relation(mentionable, klass, opts = {})
-          rel = klass.where(:id =>
+          rel = klass.where(klass.primary_key =>
             self.select(:mentioner_id).
               where(:mentioner_type => klass.table_name.classify).
               where(:mentionable_type => mentionable.class.to_s).
@@ -74,7 +74,7 @@ module Socialization
 
         # Returns an ActiveRecord::Relation of all the mentionables of a certain type that are mentioned by mentioner
         def mentionables_relation(mentioner, klass, opts = {})
-          rel = klass.where(:id =>
+          rel = klass.where(klass.primary_key =>
             self.select(:mentionable_id).
               where(:mentionable_type => klass.table_name.classify).
               where(:mentioner_type => mentioner.class.to_s).


### PR DESCRIPTION
This is needed for when someone’s model uses `self.primary_key =
:whatever_id` or in legacy databases where `id` is not the primary
key’s name.
