### PR TITLE
Adding support for STI classes

### DIFF
--- a/lib/socialization/stores/active_record/follow.rb
+++ b/lib/socialization/stores/active_record/follow.rb
@@ -55,7 +55,7 @@ module Socialization
           rel = klass.where(:id =>
             self.select(:follower_id).
               where(:follower_type => klass.table_name.classify).
-              where(:followable_type => followable.class.to_s).
+              where(:followable_type => followable.class.table_name.classify).
               where(:followable_id => followable.id)
           )
 
@@ -81,7 +81,7 @@ module Socialization
           rel = klass.where(:id =>
             self.select(:followable_id).
               where(:followable_type => klass.table_name.classify).
-              where(:follower_type => follower.class.to_s).
+              where(:follower_type => follower.class.table_name.classify).
               where(:follower_id => follower.id)
           )
 
@@ -104,13 +104,13 @@ module Socialization
 
         # Remove all the followers for followable
         def remove_followers(followable)
-          self.where(:followable_type => followable.class.name.classify).
+          self.where(:followable_type => followable.class.table_name.classify).
                where(:followable_id => followable.id).destroy_all
         end
 
         # Remove all the followables for follower
         def remove_followables(follower)
-          self.where(:follower_type => follower.class.name.classify).
+          self.where(:follower_type => follower.class.table_name.classify).
                where(:follower_id => follower.id).destroy_all
         end
 

--- a/lib/socialization/stores/active_record/like.rb
+++ b/lib/socialization/stores/active_record/like.rb
@@ -55,7 +55,7 @@ module Socialization
           rel = klass.where(:id =>
             self.select(:liker_id).
               where(:liker_type => klass.table_name.classify).
-              where(:likeable_type => likeable.class.to_s).
+              where(:likeable_type => likeable.class.table_name.classify).
               where(:likeable_id => likeable.id)
           )
 
@@ -81,7 +81,7 @@ module Socialization
           rel = klass.where(:id =>
             self.select(:likeable_id).
               where(:likeable_type => klass.table_name.classify).
-              where(:liker_type => liker.class.to_s).
+              where(:liker_type => liker.class.table_name.classify).
               where(:liker_id => liker.id)
           )
 
@@ -104,13 +104,13 @@ module Socialization
 
         # Remove all the likers for likeable
         def remove_likers(likeable)
-          self.where(:likeable_type => likeable.class.name.classify).
+          self.where(:likeable_type => likeable.class.table_name.classify).
                where(:likeable_id => likeable.id).destroy_all
         end
 
         # Remove all the likeables for liker
         def remove_likeables(liker)
-          self.where(:liker_type => liker.class.name.classify).
+          self.where(:liker_type => liker.class.table_name.classify).
                where(:liker_id => liker.id).destroy_all
         end
 

--- a/lib/socialization/stores/active_record/mention.rb
+++ b/lib/socialization/stores/active_record/mention.rb
@@ -55,7 +55,7 @@ module Socialization
           rel = klass.where(:id =>
             self.select(:mentioner_id).
               where(:mentioner_type => klass.table_name.classify).
-              where(:mentionable_type => mentionable.class.to_s).
+              where(:mentionable_type => mentionable.class.table_name.classify).
               where(:mentionable_id => mentionable.id)
           )
 
@@ -81,7 +81,7 @@ module Socialization
           rel = klass.where(:id =>
             self.select(:mentionable_id).
               where(:mentionable_type => klass.table_name.classify).
-              where(:mentioner_type => mentioner.class.to_s).
+              where(:mentioner_type => mentioner.class.table_name.classify).
               where(:mentioner_id => mentioner.id)
           )
 
@@ -104,13 +104,13 @@ module Socialization
 
         # Remove all the mentioners for mentionable
         def remove_mentioners(mentionable)
-          self.where(:mentionable_type => mentionable.class.name.classify).
+          self.where(:mentionable_type => mentionable.class.table_name.classify).
                where(:mentionable_id => mentionable.id).destroy_all
         end
 
         # Remove all the mentionables for mentioner
         def remove_mentionables(mentioner)
-          self.where(:mentioner_type => mentioner.class.name.classify).
+          self.where(:mentioner_type => mentioner.class.table_name.classify).
                where(:mentioner_id => mentioner.id).destroy_all
         end
 

--- a/spec/spec_support/data_stores.rb
+++ b/spec/spec_support/data_stores.rb
@@ -181,6 +181,7 @@ class ::ImAFollowerWithCounterCache < ActiveRecord::Base
   acts_as_follower
 end
 class ::ImAFollowerChild < ImAFollower; end
+class ::ImAFollowerChildWithCounterCache < ImAFollowerWithCounterCache; end
 
 class ::ImAFollowable < ActiveRecord::Base
   acts_as_followable
@@ -189,6 +190,7 @@ class ::ImAFollowableWithCounterCache < ActiveRecord::Base
   acts_as_followable
 end
 class ::ImAFollowableChild < ImAFollowable; end
+class ::ImAFollowableChildWithCounterCache < ImAFollowableWithCounterCache; end
 
 class ::ImALiker < ActiveRecord::Base
   acts_as_liker
@@ -197,6 +199,7 @@ class ::ImALikerWithCounterCache < ActiveRecord::Base
   acts_as_liker
 end
 class ::ImALikerChild < ImALiker; end
+class ::ImALikerChildWithCounterCache < ImALikerWithCounterCache; end
 
 class ::ImALikeable < ActiveRecord::Base
   acts_as_likeable
@@ -205,6 +208,7 @@ class ::ImALikeableWithCounterCache < ActiveRecord::Base
   acts_as_likeable
 end
 class ::ImALikeableChild < ImALikeable; end
+class ::ImALikeableChildWithCounterCache < ImALikeableWithCounterCache; end
 
 class ::ImAMentioner < ActiveRecord::Base
   acts_as_mentioner
@@ -213,6 +217,7 @@ class ::ImAMentionerWithCounterCache < ActiveRecord::Base
   acts_as_mentioner
 end
 class ::ImAMentionerChild < ImAMentioner; end
+class ::ImAMentionerChildWithCounterCache < ImAMentionerWithCounterCache; end
 
 class ::ImAMentionable < ActiveRecord::Base
   acts_as_mentionable
@@ -221,6 +226,7 @@ class ::ImAMentionableWithCounterCache < ActiveRecord::Base
   acts_as_mentionable
 end
 class ::ImAMentionableChild < ImAMentionable; end
+class ::ImAMentionableChildWithCounterCache < ImAMentionableWithCounterCache; end
 
 class ::ImAMentionerAndMentionable < ActiveRecord::Base
   acts_as_mentioner

--- a/spec/spec_support/matchers.rb
+++ b/spec/spec_support/matchers.rb
@@ -19,36 +19,36 @@ end
 
 RSpec::Matchers.define :match_follower do |expected|
   match do |actual|
-    expected.follower_type == actual.class.to_s && expected.follower_id == actual.id
+    expected.follower_type == actual.class.table_name.classify && expected.follower_id == actual.id
   end
 end
 
 RSpec::Matchers.define :match_followable do |expected|
   match do |actual|
-    expected.followable_type == actual.class.to_s && expected.followable_id == actual.id
+    expected.followable_type == actual.class.table_name.classify && expected.followable_id == actual.id
   end
 end
 
 RSpec::Matchers.define :match_liker do |expected|
   match do |actual|
-    expected.liker_type == actual.class.to_s && expected.liker_id == actual.id
+    expected.liker_type == actual.class.table_name.classify && expected.liker_id == actual.id
   end
 end
 
 RSpec::Matchers.define :match_likeable do |expected|
   match do |actual|
-    expected.likeable_type == actual.class.to_s && expected.likeable_id == actual.id
+    expected.likeable_type == actual.class.table_name.classify && expected.likeable_id == actual.id
   end
 end
 
 RSpec::Matchers.define :match_mentioner do |expected|
   match do |actual|
-    expected.mentioner_type == actual.class.to_s && expected.mentioner_id == actual.id
+    expected.mentioner_type == actual.class.table_name.classify && expected.mentioner_id == actual.id
   end
 end
 
 RSpec::Matchers.define :match_mentionable do |expected|
   match do |actual|
-    expected.mentionable_type == actual.class.to_s && expected.mentionable_id == actual.id
+    expected.mentionable_type == actual.class.table_name.classify && expected.mentionable_id == actual.id
   end
 end


### PR DESCRIPTION
- Some relations were using the class name to query the polymorphic
  associations instead of the base class name. This is inconsistent with
  Rails' recommentation about using polymorphic associations with STI:
  http://edgeapi.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#module-ActiveRecord::Associations::ClassMethods-label-Polymorphic+Associations