### PR TITLE
Return active records instead of array of elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.1 (January 8, 2014)
 
-* Supports Rails 4
+* Supports Rails 4 (thanks @thomas88)
 * Dropping official support for Ruby 1.8.x, 1.9.2.
 
 

--- a/lib/socialization/stores/active_record/follow.rb
+++ b/lib/socialization/stores/active_record/follow.rb
@@ -52,7 +52,7 @@ module Socialization
             self.select(:follower_id).
               where(:follower_type => klass.table_name.classify).
               where(:followable_type => followable.class.to_s).
-              where(:followable_id => followable.id)
+              where(:followable_id => followable.id).order("created_at desc")
           )
 
           if opts[:pluck]
@@ -79,7 +79,7 @@ module Socialization
             self.select(:followable_id).
               where(:followable_type => klass.table_name.classify).
               where(:follower_type => follower.class.to_s).
-              where(:follower_id => follower.id)
+              where(:follower_id => follower.id).order("created_at desc")
           )
 
           if opts[:pluck]

--- a/lib/socialization/stores/active_record/follow.rb
+++ b/lib/socialization/stores/active_record/follow.rb
@@ -64,12 +64,13 @@ module Socialization
 
         # Returns all the followers of a certain type that are following followable
         def followers(followable, klass, opts = {})
-          rel = followers_relation(followable, klass, opts)
-          if rel.is_a?(ActiveRecord::Relation)
-            rel.to_a
-          else
-            rel
-          end
+          followers_relation(followable, klass, opts)
+          # rel = followers_relation(followable, klass, opts)
+          # if rel.is_a?(ActiveRecord::Relation)
+          #   rel.to_a
+          # else
+          #   rel
+          # end
         end
 
         # Returns an ActiveRecord::Relation of all the followables of a certain type that are followed by follower
@@ -90,12 +91,13 @@ module Socialization
 
         # Returns all the followables of a certain type that are followed by follower
         def followables(follower, klass, opts = {})
-          rel = followables_relation(follower, klass, opts)
-          if rel.is_a?(ActiveRecord::Relation)
-            rel.to_a
-          else
-            rel
-          end
+          followables_relation(follower, klass, opts)
+          # rel = followables_relation(follower, klass, opts)
+          # if rel.is_a?(ActiveRecord::Relation)
+          #   rel.to_a
+          # else
+          #   rel
+          # end
         end
 
         # Remove all the followers for followable

--- a/lib/socialization/stores/active_record/like.rb
+++ b/lib/socialization/stores/active_record/like.rb
@@ -64,12 +64,13 @@ module Socialization
 
         # Returns all the likers of a certain type that are liking  likeable
         def likers(likeable, klass, opts = {})
-          rel = likers_relation(likeable, klass, opts)
-          if rel.is_a?(ActiveRecord::Relation)
-            rel.to_a
-          else
-            rel
-          end
+          likers_relation(likeable, klass, opts)
+          # rel = likers_relation(likeable, klass, opts)
+          # if rel.is_a?(ActiveRecord::Relation)
+          #   rel.to_a
+          # else
+          #   rel
+          # end
         end
 
         # Returns an ActiveRecord::Relation of all the likeables of a certain type that are liked by liker
@@ -90,12 +91,13 @@ module Socialization
 
         # Returns all the likeables of a certain type that are liked by liker
         def likeables(liker, klass, opts = {})
-          rel = likeables_relation(liker, klass, opts)
-          if rel.is_a?(ActiveRecord::Relation)
-            rel.to_a
-          else
-            rel
-          end
+          likeables_relation(liker, klass, opts)
+          # rel = likeables_relation(liker, klass, opts)
+          # if rel.is_a?(ActiveRecord::Relation)
+          #   rel.to_a
+          # else
+          #   rel
+          # end
         end
 
         # Remove all the likers for likeable

--- a/lib/socialization/stores/active_record/mention.rb
+++ b/lib/socialization/stores/active_record/mention.rb
@@ -64,12 +64,13 @@ module Socialization
 
         # Returns all the mentioners of a certain type that are mentioning mentionable
         def mentioners(mentionable, klass, opts = {})
-          rel = mentioners_relation(mentionable, klass, opts)
-          if rel.is_a?(ActiveRecord::Relation)
-            rel.to_a
-          else
-            rel
-          end
+          mentioners_relation(mentionable, klass, opts)
+          # rel = mentioners_relation(mentionable, klass, opts)
+          # if rel.is_a?(ActiveRecord::Relation)
+          #   rel.to_a
+          # else
+          #   rel
+          # end
         end
 
         # Returns an ActiveRecord::Relation of all the mentionables of a certain type that are mentioned by mentioner
@@ -90,12 +91,13 @@ module Socialization
 
         # Returns all the mentionables of a certain type that are mentioned by mentioner
         def mentionables(mentioner, klass, opts = {})
-          rel = mentionables_relation(mentioner, klass, opts)
-          if rel.is_a?(ActiveRecord::Relation)
-            rel.to_a
-          else
-            rel
-          end
+          mentionables_relation(mentioner, klass, opts)
+          # rel = mentionables_relation(mentioner, klass, opts)
+          # if rel.is_a?(ActiveRecord::Relation)
+          #   rel.to_a
+          # else
+          #   rel
+          # end
         end
 
         # Remove all the mentioners for mentionable


### PR DESCRIPTION
This PR return a active records instead of data array, also order the results.