### PR TITLE
Remove has_rdoc

### DIFF
--- a/socialization.gemspec
+++ b/socialization.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.has_rdoc = false
-
   s.add_runtime_dependency "activerecord"
 
   s.add_development_dependency "appraisal"


### PR DESCRIPTION
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
https://www.rubydoc.info/github/rubygems/rubygems/Gem%2FSpecification:has_rdoc